### PR TITLE
Add supported-extensions support

### DIFF
--- a/src/dcat-ap/dcat-dataset.test.ts
+++ b/src/dcat-ap/dcat-dataset.test.ts
@@ -102,13 +102,12 @@ describe('DcatDataset', () => {
     )
   })
 
-  // TODO - skipped until we expose these capabilities in the API
-  it.skip('correctly reports WFS/WMS support', function() {
+  it('correctly reports WFS/WMS support', function() {
     const supportsWFS = cloneObject(datasetFromApi)
     const supportsWMS = cloneObject(datasetFromApi)
 
-    // supportsWFS.server.supportedExtensions = 'WFSServer'
-    // supportsWMS.server.supportedExtensions = 'WMSServer'
+    supportsWFS.supportedExtensions = 'WFSServer'
+    supportsWMS.supportedExtensions = 'WMSServer'
 
     const datasetWFS = new DcatDataset(supportsWFS, orgBaseUrl, orgTitle, siteUrl)
     const datasetWMS = new DcatDataset(supportsWMS, orgBaseUrl, orgTitle, siteUrl)

--- a/src/dcat-ap/dcat-dataset.ts
+++ b/src/dcat-ap/dcat-dataset.ts
@@ -84,7 +84,7 @@ export class DcatDataset {
 
   get isFeatureLayer (): boolean { return /_/.test(this.id); }
   get hasGeometryType (): boolean { return !!this._get('geometryType'); }
-  private get _supportedExtensions () { return _.get(this._dto, 'server.supportedExtensions'); }
+  private get _supportedExtensions () { return _.get(this._dto, 'supportedExtensions'); }
   get supportsWFS (): boolean { return this._supportedExtensions && this._supportedExtensions.includes('WFSServer'); }
   get supportsWMS (): boolean { return this._supportedExtensions && this._supportedExtensions.includes('WMSServer'); }
 

--- a/src/test-helpers/mock-dataset.json
+++ b/src/test-helpers/mock-dataset.json
@@ -68,6 +68,7 @@
     ],
     "type": "envelope"
   },
+  "supportedExtensions": "",
   "fieldNames": [
     "OBJECTID",
     "GlobalID",


### PR DESCRIPTION
I didn't think `supportedExtensions` was returned by our API, but I was wrong!

See https://github.com/ArcGIS/hub-indexer/blob/34ad929b1a09e20c8199e7cd964d007d25d3595c/packages/api/schema.json#L865-L874