### PR TITLE
F/2393 add custom config support

### DIFF
--- a/src/dcat-ap/dcat-dataset.ts
+++ b/src/dcat-ap/dcat-dataset.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import { isPage } from '@esri/hub-sites';
 import { UserSession } from '@esri/arcgis-rest-auth';
 
-export const requiredFields = [
+export const defaultRequiredFields = [
   'id',
   'url',
   'owner',
@@ -20,6 +20,57 @@ export const requiredFields = [
   'geometryType',
   'orgContactEmail'
 ];
+
+export function getDcatDataset(hubDataset: any, orgBaseUrl: string, orgTitle: string, siteUrl: string) {
+  return Object.assign({}, hubDataset, {
+    landingPage: `${siteUrl}/datasets/${hubDataset.id}`,
+    ownerUri: getUserUrl({
+        portal: `${orgBaseUrl}/sharing/rest`,
+        username: hubDataset.owner
+      } as UserSession) + '?f=json',
+    language: _.get(hubDataset, 'metadata.metadata.dataIdInfo.dataLang.languageCode.@_value') || localeToLang(hubDataset.culture) || null,
+    keyword: getDatasetKeyword(hubDataset),
+    issuedDateTime: _.get(hubDataset, 'metadata.metadata.dataIdInfo.idCitation.date.pubDate') || new Date(hubDataset.created).toISOString(),
+    orgTitle,
+    provenance: _.get(hubDataset, 'metadata.metadata.dataIdInfo.idCredit', null),
+  });
+}
+
+function getDatasetKeyword(dataset: any) {
+    const metaKeyword = _.get(dataset, 'metadata.metadata.dataIdInfo.searchKeys.keyword');
+    
+    if (metaKeyword) {
+      return metaKeyword;
+    }
+
+    const { tags, type, typeKeywords } = dataset;
+    const hasNoTags = !tags || tags.length === 0 || !tags[0]; // if tags is undefined, the tags array is empty, or tags is an empty string
+    
+    if (isPage({ type, typeKeywords } as IItem) && hasNoTags) {
+      return ['ArcGIS Hub page'];
+    }
+
+    return tags;
+}
+
+// TODO: Should we test these individually?
+export const isFeatureLayer = (dcatDataset: any) => /_/.test(dcatDataset.id);
+export const hasGeometryType = (dcatDataset: any) => !!dcatDataset.geometryType;
+export const supportsWFS = (dcatDataset: any) => _.get(dcatDataset, 'supportedExtensions', []).includes('WFSServer');
+export const supportsWMS = (dcatDataset: any) => _.get(dcatDataset, 'supportedExtensions', []).includes(('WMSServer'));
+export const getDownloadUrl = (dcatDataset: any, format: 'geojson'|'kml'|'csv'|'zip') => {
+  const spatialReference = _.get(dcatDataset, 'server.spatialReference');
+  let queryStr = '';
+  if (spatialReference) {
+    const { latestWkid, wkid } = spatialReference;
+    if (wkid) {
+      const outSR = JSON.stringify({ latestWkid, wkid });
+      queryStr = `?outSR=${encodeURIComponent(outSR)}`;
+    }
+  }
+  return `${dcatDataset.landingPage}.${format}${queryStr}`;
+};
+export const getOgcUrl = (dcatDataset: any, type: 'WMS'|'WFS' = 'WMS') => dcatDataset.url.replace(/rest\/services/i, 'services').replace(/\d+$/, `${type}Server?request=GetCapabilities&service=${type}`);
 
 export class DcatDataset {
   private _dto: any;

--- a/src/dcat-ap/dcat-dataset.ts
+++ b/src/dcat-ap/dcat-dataset.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { isPage } from '@esri/hub-sites';
 import { UserSession } from '@esri/arcgis-rest-auth';
 
+// Required fields from the API
 export const defaultRequiredFields = [
   'id',
   'url',
@@ -21,6 +22,17 @@ export const defaultRequiredFields = [
   'orgContactEmail'
 ];
 
+// Fields calculated from API Values
+export const defaultCalculatedFields = [
+  'landingPage',
+  'ownerUri',
+  'language',
+  'keyword',
+  'issuedDateTime',
+  'orgTitle',
+  'provenance'
+];
+
 export function getDcatDataset(hubDataset: any, orgBaseUrl: string, orgTitle: string, siteUrl: string) {
   return Object.assign({}, hubDataset, {
     landingPage: `${siteUrl}/datasets/${hubDataset.id}`,
@@ -28,11 +40,11 @@ export function getDcatDataset(hubDataset: any, orgBaseUrl: string, orgTitle: st
         portal: `${orgBaseUrl}/sharing/rest`,
         username: hubDataset.owner
       } as UserSession) + '?f=json',
-    language: _.get(hubDataset, 'metadata.metadata.dataIdInfo.dataLang.languageCode.@_value') || localeToLang(hubDataset.culture) || null,
+    language: _.get(hubDataset, 'metadata.metadata.dataIdInfo.dataLang.languageCode.@_value') || localeToLang(hubDataset.culture) || '',
     keyword: getDatasetKeyword(hubDataset),
     issuedDateTime: _.get(hubDataset, 'metadata.metadata.dataIdInfo.idCitation.date.pubDate') || new Date(hubDataset.created).toISOString(),
     orgTitle,
-    provenance: _.get(hubDataset, 'metadata.metadata.dataIdInfo.idCredit', null),
+    provenance: _.get(hubDataset, 'metadata.metadata.dataIdInfo.idCredit', ''),
   });
 }
 
@@ -71,104 +83,3 @@ export const getDownloadUrl = (dcatDataset: any, format: 'geojson'|'kml'|'csv'|'
   return `${dcatDataset.landingPage}.${format}${queryStr}`;
 };
 export const getOgcUrl = (dcatDataset: any, type: 'WMS'|'WFS' = 'WMS') => dcatDataset.url.replace(/rest\/services/i, 'services').replace(/\d+$/, `${type}Server?request=GetCapabilities&service=${type}`);
-
-export class DcatDataset {
-  private _dto: any;
-  private _orgBaseUrl: string;
-  private _orgTitle: string;
-  private _siteUrl: string;
-
-  constructor (dto: any, orgBaseUrl: string, orgTitle: string, siteUrl: string) {
-    this._dto = dto;
-    this._orgBaseUrl = orgBaseUrl;
-    this._orgTitle = orgTitle;
-    this._siteUrl = siteUrl;
-  }
-
-  /**
-    * Lookup fn
-    */
-  private _get (path) {
-    return _.get(this._dto, path, null);
-  }
-
-  get id (): string { return this._get('id'); }
-  get url (): string { return this._get('url'); }
-  get landingPage (): string { return `${this._siteUrl}/datasets/${this.id}`; }
-  get title (): string { return this._get('name'); }
-  get description (): string { return this._get('description'); }
-  get owner (): string { return this._get('owner'); }
-  get ownerUri (): string {
-    return getUserUrl({
-      portal: `${this._orgBaseUrl}/sharing/rest`,
-      username: this.owner
-    } as UserSession) + '?f=json';
-  }
-
-  get language (): string {
-    return this._metaLanguage || localeToLang(this._get('culture')) || null;
-  }
-
-  get keyword (): string[] {
-    if (this._metaKeyword) {
-      return this._metaKeyword;
-    }
-
-    let tags = this._get('tags');
-
-    const hasNoTags = !tags || tags.length === 0 || !tags[0]; // if tags is undefined, the tags array is empty, or tags is an empty string
-    if (isPage({
-      type: this._dto.type,
-      typeKeywords: this._dto.typeKeywords
-    } as IItem) && hasNoTags) {
-      tags = ['ArcGIS Hub page'];
-    }
-
-    return tags;
-  }
-
-  /**
-    * Returns an ISO string
-    */
-  get issuedDateTime (): string {
-    return this._metaPubDate || new Date(this._get('created')).toISOString();
-  }
-
-  get isFeatureLayer (): boolean { return /_/.test(this.id); }
-  get hasGeometryType (): boolean { return !!this._get('geometryType'); }
-  private get _supportedExtensions () { return _.get(this._dto, 'supportedExtensions'); }
-  get supportsWFS (): boolean { return this._supportedExtensions && this._supportedExtensions.includes('WFSServer'); }
-  get supportsWMS (): boolean { return this._supportedExtensions && this._supportedExtensions.includes('WMSServer'); }
-
-  get orgTitle (): string { return this._orgTitle; }
-
-  // TODO - add to search API
-  get orgContactUrl (): string { return this._get('orgContactEmail'); }
-
-  /* BEGIN INSPIRE METADATA PROPS (may want to introduce a metadata class to manage formats eventually) */
-
-  get provenance (): string { return this._get('metadata.metadata.dataIdInfo.idCredit'); }
-  private get _metaKeyword (): string[] { return this._get('metadata.metadata.dataIdInfo.searchKeys.keyword'); }
-  private get _metaLanguage (): string { return this._get('metadata.metadata.dataIdInfo.dataLang.languageCode.@_value'); }
-  private get _metaPubDate (): string { return this._get('metadata.metadata.dataIdInfo.idCitation.date.pubDate'); }
-
-  /* BEGIN METHODS */
-
-  getDownloadUrl (format: 'geojson'|'kml'|'csv'|'zip') {
-    // get spatial reference
-    const spatialReference = this._get('server.spatialReference');
-    let queryStr = '';
-    if (spatialReference) {
-      const { latestWkid, wkid } = spatialReference;
-      if (wkid) {
-        const outSR = JSON.stringify({ latestWkid, wkid });
-        queryStr = `?outSR=${encodeURIComponent(outSR)}`;
-      }
-    }
-    return `${this.landingPage}.${format}${queryStr}`;
-  }
-
-  getOgcUrl (type: 'WMS'|'WFS' = 'WMS') {
-    return this.url.replace(/rest\/services/i, 'services').replace(/\d+$/, `${type}Server?request=GetCapabilities&service=${type}`);
-  }
-}

--- a/src/dcat-ap/dcat-formatters.test.ts
+++ b/src/dcat-ap/dcat-formatters.test.ts
@@ -1,9 +1,11 @@
-import { DcatDataset } from './dcat-dataset';
+// import * as dcatDatasetModule from './dcat-dataset';
 import { formatDcatDataset } from './dcat-formatters';
+import { defaultFormatTemplate }  from '../default-format-template';
 
-const dataset = {
-  landingPage: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/',
-  title: 'Jules Goes The Distance',
+const dataset: any = {
+  landingPage: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0',
+  id: '0',
+  name: 'Jules Goes The Distance',
   description:
     'Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.',
   ownerUri: '',
@@ -12,21 +14,17 @@ const dataset = {
   orgTitle: '',
   language: 'eng',
   keyword: ['property', 'vacant', 'abandoned', 'revitalization'],
-  metaProvenance: '',
+  provenance: 'provenance',
   issuedDateTime: 1498771743000,
   url: 'https://sampleserver3.arcgisonline.com/arcgis/rest/services/Earthquakes/RecentEarthquakesRendered/MapServer/0',
-  getDownloadUrl() {
-    return 'foobar-url.com';
-  },
-  getOgcUrl: () => 'foobar-url.com',
-} as unknown as DcatDataset;
+};
 
 describe('formatDcatDataset', () => {
   it('DCAT dataset has correct format', function () {
     const expectedResult = {
       '@type': 'dcat:Dataset',
       '@id': dataset.landingPage,
-      'dct:title': dataset.title,
+      'dct:title': dataset.name,
       'dct:description': dataset.description,
       'dcat:contactPoint': {
         '@id': dataset.ownerUri,
@@ -45,7 +43,7 @@ describe('formatDcatDataset', () => {
       'dct:provenance': dataset.provenance,
       'dct:issued': dataset.issuedDateTime,
     };
-    const result = JSON.parse(formatDcatDataset(dataset));
+    const result = JSON.parse(formatDcatDataset(dataset, defaultFormatTemplate));
 
     expect(result['@type']).toBe(expectedResult['@type']);
     expect(result['@id']).toBe(expectedResult['@id']);
@@ -57,7 +55,7 @@ describe('formatDcatDataset', () => {
     expect(result['dct:publisher']).toBe(expectedResult['dct:publisher']);
     expect(result['dcat:theme']).toBe(expectedResult['dcat:theme']);
     expect(result['dct:accessRights']).toBe(expectedResult['dct:accessRights']);
-    expect(result['dct:indentifier']).toBe(expectedResult['dct:indentifier']);
+    expect(result['dct:identifier']).toBe(expectedResult['dct:identifier']);
     expect(result['dct:language']).toEqual(expectedResult['dct:language']);
     expect(result['dcat:keyword']).toEqual(expectedResult['dcat:keyword']);
     expect(result['dct:provenance']).toBe(expectedResult['dct:provenance']);
@@ -66,8 +64,8 @@ describe('formatDcatDataset', () => {
   });
 
   it('DCAT language node null if no language', function () {
-    const withoutLanguage = { ...dataset, language: '' } as DcatDataset;
-    const result = JSON.parse(formatDcatDataset(withoutLanguage));
+    const withoutLanguage = { ...dataset, language: null };
+    const result = JSON.parse(formatDcatDataset(withoutLanguage, defaultFormatTemplate));
 
     expect(result['dct:language']).toBe(null);
   });
@@ -75,16 +73,16 @@ describe('formatDcatDataset', () => {
   it('DCAT distributions have correct format', function () {
     const distDataset = {
       ...dataset,
-      isFeatureLayer: true,
-      hasGeometryType: true,
-      supportsWFS: true,
-      supportsWMS: true,
-    } as DcatDataset;
+      landingPage: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0',
+      id: '0_0',
+      geometryType: 'point',
+      supportedExtensions: ['WFSServer', 'WMSServer']
+    };
     const expectedResult = {
       html: {
         '@type': 'dcat:Distribution',
         'dcat:accessUrl':
-          'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/',
+          'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0',
         'dct:format': {
           '@id': 'ftype:HTML',
         },
@@ -103,7 +101,7 @@ describe('formatDcatDataset', () => {
       },
       geoJSON: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0.geojson',
         'dct:format': {
           '@id': 'ftype:GEOJSON',
         },
@@ -112,7 +110,7 @@ describe('formatDcatDataset', () => {
       },
       csv: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0.csv',
         'dct:format': {
           '@id': 'ftype:CSV',
         },
@@ -121,7 +119,7 @@ describe('formatDcatDataset', () => {
       },
       wfs: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WFSServer?request=GetCapabilities&service=WFS',
         'dct:format': {
           '@id': 'ftype:WFS_SRVC',
         },
@@ -130,7 +128,7 @@ describe('formatDcatDataset', () => {
       },
       kml: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0.kml',
         'dct:format': {
           '@id': 'ftype:KML',
         },
@@ -139,7 +137,7 @@ describe('formatDcatDataset', () => {
       },
       zip: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0.zip',
         'dct:format': {
           '@id': 'ftype:ZIP',
         },
@@ -148,7 +146,7 @@ describe('formatDcatDataset', () => {
       },
       wms: {
         '@type': 'dcat:Distribution',
-        'dcat:accessUrl': 'foobar-url.com',
+        'dcat:accessUrl': 'https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WMSServer?request=GetCapabilities&service=WMS',
         'dct:format': {
           '@id': 'ftype:WMS_SRVC',
         },
@@ -156,7 +154,7 @@ describe('formatDcatDataset', () => {
         'dct:title': 'OGC WMS',
       },
     };
-    const result = JSON.parse(formatDcatDataset(distDataset));
+    const result = JSON.parse(formatDcatDataset(distDataset, defaultFormatTemplate));
     expect(result['dcat:distribution'][0]).toEqual(expectedResult.html);
     expect(result['dcat:distribution'][1]).toEqual(expectedResult.restAPI);
     expect(result['dcat:distribution'][2]).toEqual(expectedResult.geoJSON);
@@ -168,7 +166,7 @@ describe('formatDcatDataset', () => {
   });
 
   it('basic DCAT distributions are generated', function () {
-    const result = JSON.parse(formatDcatDataset(dataset));
+    const result = JSON.parse(formatDcatDataset(dataset, defaultFormatTemplate));
     const dist1 = result['dcat:distribution'][0]['dct:title'];
     const dist2 = result['dcat:distribution'][1]['dct:title'];
 
@@ -180,9 +178,9 @@ describe('formatDcatDataset', () => {
   it('FeatureLayer DCAT distributions are generated', function () {
     const featureLayerDataset = {
       ...dataset,
-      isFeatureLayer: true,
-    } as DcatDataset;
-    const result = JSON.parse(formatDcatDataset(featureLayerDataset));
+      id: '0_0',
+    };
+    const result = JSON.parse(formatDcatDataset(featureLayerDataset, defaultFormatTemplate));
     const dist1 = result['dcat:distribution'][2]['dct:title'];
     const dist2 = result['dcat:distribution'][3]['dct:title'];
 
@@ -196,8 +194,10 @@ describe('formatDcatDataset', () => {
       ...dataset,
       isFeatureLayer: true,
       hasGeometryType: true,
-    } as DcatDataset;
-    const result = JSON.parse(formatDcatDataset(featureLayerDataset));
+      id: '0_0',
+      geometryType: 'point',
+    };
+    const result = JSON.parse(formatDcatDataset(featureLayerDataset, defaultFormatTemplate));
     const dist1 = result['dcat:distribution'][4]['dct:title'];
     const dist2 = result['dcat:distribution'][5]['dct:title'];
 
@@ -207,8 +207,11 @@ describe('formatDcatDataset', () => {
   });
 
   it('DCAT distributions include WFS when supported', function () {
-    const WFSDataset = { ...dataset, supportsWFS: true } as DcatDataset;
-    const result = JSON.parse(formatDcatDataset(WFSDataset));
+    const WFSDataset = { 
+      ...dataset,
+      supportedExtensions: ['WFSServer']
+    };
+    const result = JSON.parse(formatDcatDataset(WFSDataset, defaultFormatTemplate));
     const dist = result['dcat:distribution'][2]['dct:title'];
 
     expect(dist).toBeTruthy();
@@ -216,8 +219,11 @@ describe('formatDcatDataset', () => {
   });
 
   it('DCAT distributions include WMS when supported', function () {
-    const WMSDataset = { ...dataset, supportsWMS: true } as DcatDataset;
-    const result = JSON.parse(formatDcatDataset(WMSDataset));
+    const WMSDataset = { 
+      ...dataset,
+      supportedExtensions: ['WMSServer']
+    };
+    const result = JSON.parse(formatDcatDataset(WMSDataset, defaultFormatTemplate));
     const dist = result['dcat:distribution'][2]['dct:title'];
 
     expect(dist).toBeTruthy();

--- a/src/dcat-ap/dcat-formatters.test.ts
+++ b/src/dcat-ap/dcat-formatters.test.ts
@@ -1,4 +1,3 @@
-// import * as dcatDatasetModule from './dcat-dataset';
 import { formatDcatDataset } from './dcat-formatters';
 import { defaultFormatTemplate }  from '../default-format-template';
 
@@ -10,7 +9,7 @@ const dataset: any = {
     'Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.',
   ownerUri: '',
   owner: 'jbartley',
-  orgContactUrl: 'contact@funorg.com',
+  orgContactEmail: 'contact@funorg.com',
   orgTitle: '',
   language: 'eng',
   keyword: ['property', 'vacant', 'abandoned', 'revitalization'],
@@ -30,7 +29,7 @@ describe('formatDcatDataset', () => {
         '@id': dataset.ownerUri,
         '@type': 'Contact',
         'vcard:fn': dataset.owner,
-        'vcard:hasEmail': dataset.orgContactUrl,
+        'vcard:hasEmail': dataset.orgContactEmail,
       },
       'dct:publisher': dataset.orgTitle,
       'dcat:theme': 'geospatial',
@@ -63,11 +62,11 @@ describe('formatDcatDataset', () => {
     expect(result['dcat:distribution']).toBeTruthy();
   });
 
-  it('DCAT language node null if no language', function () {
+  it('DCAT language node empty if no language', function () {
     const withoutLanguage = { ...dataset, language: null };
     const result = JSON.parse(formatDcatDataset(withoutLanguage, defaultFormatTemplate));
 
-    expect(result['dct:language']).toBe(null);
+    expect(result['dct:language']).toBe('');
   });
 
   it('DCAT distributions have correct format', function () {

--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -1,26 +1,24 @@
 import { IItem } from '@esri/arcgis-rest-portal';
 import {
   cloneObject,
-  deleteProp,
-  getProp,
   IDomainEntry,
 } from '@esri/hub-common';
 import { readableFromArray, streamToString } from '../test-helpers/stream-utils';
 import { getDataStreamDcatAp201 } from './';
 import * as datasetFromApi from '../test-helpers/mock-dataset.json';
-import { defaultFormatTemplate } from '../default-format-template';
 
-function generateDcatFeed(
+async function generateDcatFeed(
   domainRecord,
   siteItem,
   datasets,
-  orgBaseUrl = 'https://qa-pre-a-hub.mapsqa.arcgis.com'
+  orgBaseUrl = 'https://qa-pre-a-hub.mapsqa.arcgis.com',
+  customFormatTemplate?
 ) {
-  const dcatStream = getDataStreamDcatAp201({ domainRecord, siteItem, orgBaseUrl, datasetFormatTemplate: defaultFormatTemplate });
+  const { dcatStream, dependencies } = getDataStreamDcatAp201({ domainRecord, siteItem, orgBaseUrl, customFormatTemplate });
 
   const docStream = readableFromArray(datasets); // no datasets since we're just checking the catalog
-
-  return streamToString(docStream.pipe(dcatStream)).then(JSON.parse);
+  const feedString = await streamToString(docStream.pipe(dcatStream));
+  return { feed: JSON.parse(feedString), dependencies };
 }
 
 const domainRecord: IDomainEntry = {
@@ -112,7 +110,7 @@ const siteItem: IItem = {
 
 describe('generating DCAT-AP 2.0.1 feed', () => {
   it('DCAT catalog formatted correctly', async function () {
-    const feed = await generateDcatFeed(domainRecord, siteItem, []);
+    const { feed } = await generateDcatFeed(domainRecord, siteItem, []);
 
     expect(feed['@context']).toEqual({
       dcat: 'http://www.w3.org/ns/dcat#',
@@ -144,7 +142,7 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
   });
 
   it('DCAT dataset prefers metadata when available', async function () {
-    const feed = await generateDcatFeed(domainRecord, siteItem, [
+    const { feed } = await generateDcatFeed(domainRecord, siteItem, [
       datasetFromApi,
     ]);
 
@@ -168,11 +166,11 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
     });
   });
 
-  it('DCAT dataset has defaults when metadata not available', async function () { // I don't think we want to default provenance to null...
+  it('DCAT dataset has defaults when metadata not available', async function () {
     const datasetWithoutMetadata = cloneObject(datasetFromApi);
     delete datasetWithoutMetadata.metadata;
 
-    const feed = await generateDcatFeed(domainRecord, siteItem, [
+    const { feed } = await generateDcatFeed(domainRecord, siteItem, [
       datasetWithoutMetadata,
     ]);
 
@@ -183,8 +181,6 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
       'just modified'
     ]);
 
-    expect(chk1['dct:provenance']).toBe(null);
-
     expect(chk1['dct:issued']).toBe('2021-01-29T15:34:38.000Z');
 
     expect(chk1['dct:language']).toEqual({
@@ -192,38 +188,8 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
     });
   });
 
-  it('DCAT dataset attributes default to null where values not available', async function () { // Not Valid anymore..
-    // define a few mappings to check
-    const mappings = [
-      // TODO - reactivate when org contact is available
-      // [
-      //   'org.portalProperties.links.contactUs.url',
-      //   'dcat:contactPoint.vcard:hasEmail',
-      // ],
-      ['metadata.metadata.dataIdInfo.idCredit', 'dct:provenance'],
-      ['name', 'dct:title'],
-    ];
-
-    const partialDataset = cloneObject(datasetFromApi);
-
-    // remove props
-    for (const mapping of mappings) {
-      deleteProp(partialDataset, mapping[0]);
-    }
-
-    const feed = await generateDcatFeed(domainRecord, siteItem, [
-      partialDataset,
-    ]);
-
-    const dcatDataset = feed['dcat:dataset'][0];
-
-    for (const mapping of mappings) {
-      expect(getProp(dcatDataset, mapping[1])).toBe(null);
-    }
-  });
-
   it('DCAT feed uses org base URL', async function () {
-    const feedProd = await generateDcatFeed(
+    const { feed: feedProd } = await generateDcatFeed(
       domainRecord,
       siteItem,
       [datasetFromApi],
@@ -235,5 +201,143 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
     expect(
       new URL(feedProd['dcat:dataset'][0]['dcat:contactPoint']['@id']).hostname,
     ).toBe('qa-pre-a-hub.mapsdev.arcgis.com');
+  });
+
+  it('respects dcat customizations of overwritable attributes', async () => {
+    const { feed } = await generateDcatFeed(
+      domainRecord, 
+      siteItem, 
+      [ datasetFromApi ],
+      'https://qa-pre-a-hub.mapsqa.arcgis.com',
+      {
+        'dct:title': 'A Nifty Title', // overwrite existing
+        'dct:new-attr': 'New Value', // new attribute
+      } 
+    );
+
+    const chk1 = feed['dcat:dataset'][0];
+
+    expect(chk1['@type']).toEqual('dcat:Dataset');
+    expect(chk1['@id']).toEqual('https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1['dct:title']).toEqual('A Nifty Title');
+    expect(chk1['dct:description']).toEqual('Description. Here be Tahoe things. You can do a lot here. Here are some more words. And a few more.<div><br /></div><div>with more words</div><div><br /></div><div>adding a few more to test how long it takes for our jobs to execute.</div><div><br /></div><div>Tom was here!</div>');
+    expect(chk1['dcat:contactPoint']).toStrictEqual({
+      '@id': 'https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/community/users/thervey_qa_pre_a_hub?f=json',
+      '@type': 'Contact',
+      'vcard:fn': 'thervey_qa_pre_a_hub',
+      'vcard:hasEmail': 'mailto:email@service.com',
+    });
+    expect(chk1['dct:publisher']).toEqual('QA Premium Alpha Hub');
+    expect(chk1['dcat:theme']).toEqual('geospatial');
+    expect(chk1['dct:accessRights']).toEqual('public');
+    expect(chk1['dct:identifier']).toEqual('https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1['dcat:keyword']).toEqual(['some', 'keywords', 'from', 'metadata']);
+    expect(chk1['dct:provenance']).toEqual('Myndigheten för samhällsskydd och beredskap ( https://www.msb.se/ ); con terra ( https://www.conterra.de/); Esri (https://www.esri.com/en-us/arcgis/products/arcgis-for-inspire)');
+    expect(chk1['dct:issued']).toEqual('2021-04-19T13:30:24.055-04:00');
+    expect(chk1['dct:language']).toStrictEqual({ '@id': 'lang:GER' });
+    expect(chk1['dct:new-attr']).toEqual('New Value');
+  });
+
+  it('scrubs dcat customization of protected fields', async () => {
+    const { feed } = await generateDcatFeed(
+      domainRecord, 
+      siteItem, 
+      [datasetFromApi],
+      'https://qa-pre-a-hub.mapsqa.arcgis.com',
+      {
+        '@type': '{{ Type Injection }}',
+        '@id': '{{ Id Injection }}',
+        'dcat:contactPoint': {
+          '@id': '{{ Contact Point Id Injection }}',
+          '@type': '{{ Contact Point Type Injection }}',
+          "vcard:fn": "{{ owner}}", // default value
+          "vcard:hasEmail": "{{ orgContactEmail }}", // default value
+        },
+        'dcat:theme': '{{ Theme Injection }}',
+        'dct:identifier': '{{ Identifier Injection}}',
+        'dcat:keyword': '{{ Keyword Injection }}',
+        'dct:issued': '{{ Issued Injection}}',
+        'dct:language': '{{ Language Injection }}',
+        'dcat:distribution': '{{ Distribution Injection }}',
+      }
+    );
+
+    const chk1 = feed['dcat:dataset'][0];
+
+    expect(chk1['@type']).toEqual('dcat:Dataset');
+    expect(chk1['@id']).toEqual('https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1['dct:title']).toEqual('Tahoe places of interest');
+    expect(chk1['dct:description']).toEqual('Description. Here be Tahoe things. You can do a lot here. Here are some more words. And a few more.<div><br /></div><div>with more words</div><div><br /></div><div>adding a few more to test how long it takes for our jobs to execute.</div><div><br /></div><div>Tom was here!</div>');
+    expect(chk1['dcat:contactPoint']).toStrictEqual({
+      '@id': 'https://qa-pre-a-hub.mapsqa.arcgis.com/sharing/rest/community/users/thervey_qa_pre_a_hub?f=json',
+      '@type': 'Contact',
+      'vcard:fn': 'thervey_qa_pre_a_hub',
+      'vcard:hasEmail': 'mailto:email@service.com',
+    });
+    expect(chk1['dct:publisher']).toEqual('QA Premium Alpha Hub');
+    expect(chk1['dcat:theme']).toEqual('geospatial');
+    expect(chk1['dct:accessRights']).toEqual('public');
+    expect(chk1['dct:identifier']).toEqual('https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1['dcat:keyword']).toEqual(['some', 'keywords', 'from', 'metadata']);
+    expect(chk1['dct:provenance']).toEqual('Myndigheten för samhällsskydd och beredskap ( https://www.msb.se/ ); con terra ( https://www.conterra.de/); Esri (https://www.esri.com/en-us/arcgis/products/arcgis-for-inspire)');
+    expect(chk1['dct:issued']).toEqual('2021-04-19T13:30:24.055-04:00');
+    expect(chk1['dct:language']).toStrictEqual({ '@id': 'lang:GER' });
+  });
+
+  it('reports default dependencies when no custom format provided', async () => {
+    const expected = [
+      'id',
+      'url',
+      'owner',
+      'name',
+      'type',
+      'typeKeywords',
+      'tags',
+      'description',
+      'culture',
+      'created',
+      'metadata',
+      'server',
+      'geometryType',
+      'orgContactEmail'
+    ];
+    const { dependencies } = await generateDcatFeed(domainRecord, siteItem, [datasetFromApi]);
+    
+    expect(dependencies).toEqual(expect.arrayContaining(expected));
+    expect(dependencies.length).toBe(expected.length);
+  });
+
+  it('reports custom dependencies when custom format provided', async () => {
+    const expected = [
+      'id',
+      'url',
+      'owner',
+      'name',
+      'type',
+      'typeKeywords',
+      'tags',
+      'description',
+      'culture',
+      'created',
+      'metadata',
+      'server',
+      'geometryType',
+      'orgContactEmail',
+      'modified.property.path',
+      'new.property.path'
+    ];
+    const { dependencies } = await generateDcatFeed(
+      domainRecord, 
+      siteItem, 
+      [datasetFromApi],
+      'https://qa-pre-a-hub.mapsqa.arcgis.com',
+      { 
+        'dct:title': '{{modified.property.path}}', // Modify default
+        property: '{{new.property.path}}' // Add new attribute
+      }
+    );
+    
+    expect(dependencies).toEqual(expect.arrayContaining(expected));
+    expect(dependencies.length).toBe(expected.length);
   });
 });

--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -8,6 +8,7 @@ import {
 import { readableFromArray, streamToString } from '../test-helpers/stream-utils';
 import { getDataStreamDcatAp201 } from './';
 import * as datasetFromApi from '../test-helpers/mock-dataset.json';
+import { defaultFormatTemplate } from '../default-format-template';
 
 function generateDcatFeed(
   domainRecord,
@@ -15,7 +16,7 @@ function generateDcatFeed(
   datasets,
   orgBaseUrl = 'https://qa-pre-a-hub.mapsqa.arcgis.com'
 ) {
-  const dcatStream = getDataStreamDcatAp201({ domainRecord, siteItem, orgBaseUrl });
+  const dcatStream = getDataStreamDcatAp201({ domainRecord, siteItem, orgBaseUrl, datasetFormatTemplate: defaultFormatTemplate });
 
   const docStream = readableFromArray(datasets); // no datasets since we're just checking the catalog
 
@@ -167,7 +168,7 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
     });
   });
 
-  it('DCAT dataset has defaults when metadata not available', async function () {
+  it('DCAT dataset has defaults when metadata not available', async function () { // I don't think we want to default provenance to null...
     const datasetWithoutMetadata = cloneObject(datasetFromApi);
     delete datasetWithoutMetadata.metadata;
 
@@ -191,7 +192,7 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
     });
   });
 
-  it('DCAT dataset attributes default to null where values not available', async function () {
+  it('DCAT dataset attributes default to null where values not available', async function () { // Not Valid anymore..
     // define a few mappings to check
     const mappings = [
       // TODO - reactivate when org contact is available

--- a/src/dcat-ap/index.ts
+++ b/src/dcat-ap/index.ts
@@ -1,13 +1,14 @@
 import { IItem } from '@esri/arcgis-rest-portal';
 import { IDomainEntry } from '@esri/hub-common';
-import { DcatDataset as Dataset } from './dcat-dataset';
-import { formatDcatCatalog, formatDcatDataset } from './dcat-formatters';
+import { getDcatDataset } from './dcat-dataset';
+import { DatasetFormatTemplate, formatDcatCatalog, formatDcatDataset } from './dcat-formatters';
 import { FeedFormatterStream } from './feed-formatter-stream';
 
 interface IDcatAPOptions {
   siteItem: IItem;
   domainRecord: IDomainEntry,
   orgBaseUrl: string;
+  datasetFormatTemplate: DatasetFormatTemplate
 }
 
 export function getDataStreamDcatAp201(options: IDcatAPOptions) {
@@ -21,13 +22,8 @@ export function getDataStreamDcatAp201(options: IDcatAPOptions) {
   const footer = '\n\t]\n}';
 
   const formatFn = (chunk) => {
-    const dataset = new Dataset(
-      chunk,
-      options.orgBaseUrl,
-      options.domainRecord.orgTitle,
-      options.siteItem.url,
-    );
-    return formatDcatDataset(dataset);
+    const dcatDataset = getDcatDataset(chunk, options.orgBaseUrl, options.domainRecord.orgTitle, options.siteItem.url);
+    return formatDcatDataset(dcatDataset, options.datasetFormatTemplate);
   };
 
   return new FeedFormatterStream(header, footer, ',\n', formatFn);

--- a/src/dcat-ap/index.ts
+++ b/src/dcat-ap/index.ts
@@ -1,14 +1,15 @@
 import { IItem } from '@esri/arcgis-rest-portal';
 import { IDomainEntry } from '@esri/hub-common';
-import { getDcatDataset } from './dcat-dataset';
-import { DatasetFormatTemplate, formatDcatCatalog, formatDcatDataset } from './dcat-formatters';
+import { defaultCalculatedFields, defaultRequiredFields, getDcatDataset } from './dcat-dataset';
+import { DatasetFormatTemplate, formatDcatCatalog, formatDcatDataset, mergeWithDefaultFormatTemplate } from './dcat-formatters';
 import { FeedFormatterStream } from './feed-formatter-stream';
+import { listDependencies } from 'adlib';
 
 interface IDcatAPOptions {
   siteItem: IItem;
   domainRecord: IDomainEntry,
   orgBaseUrl: string;
-  datasetFormatTemplate: DatasetFormatTemplate
+  customFormatTemplate?: DatasetFormatTemplate
 }
 
 export function getDataStreamDcatAp201(options: IDcatAPOptions) {
@@ -20,11 +21,21 @@ export function getDataStreamDcatAp201(options: IDcatAPOptions) {
   )},\n\t"dcat:dataset": [\n`;
 
   const footer = '\n\t]\n}';
-
+  
+  const datasetFormatTemplate = mergeWithDefaultFormatTemplate(options.customFormatTemplate);
   const formatFn = (chunk) => {
     const dcatDataset = getDcatDataset(chunk, options.orgBaseUrl, options.domainRecord.orgTitle, options.siteItem.url);
-    return formatDcatDataset(dcatDataset, options.datasetFormatTemplate);
+    return formatDcatDataset(dcatDataset, datasetFormatTemplate);
   };
 
-  return new FeedFormatterStream(header, footer, ',\n', formatFn);
+  return {
+    dcatStream: new FeedFormatterStream(header, footer, ',\n', formatFn),
+    dependencies: Array.from(
+      new Set([
+      ...defaultRequiredFields,
+      ...listDependencies(datasetFormatTemplate)
+          .filter(dependency => !defaultCalculatedFields.includes(dependency))
+      ])
+    )
+  };
 }

--- a/src/default-format-template.ts
+++ b/src/default-format-template.ts
@@ -1,22 +1,22 @@
 import { DatasetFormatTemplate } from "./dcat-ap/dcat-formatters";
 
 export const defaultFormatTemplate: DatasetFormatTemplate = {
-    '@type': 'dcat:Dataset', // cannot be overwritten
-    '@id': '{{landingPage}}', // cannot be overwritten (or can it?)
+    '@type': 'dcat:Dataset', // can't be overwritten
+    '@id': '{{landingPage}}', // can't be overwritten
     'dct:title': '{{name}}',
     'dct:description': '{{description}}',
     'dcat:contactPoint': {
-        '@id': '{{ownerUri}}', // should this be overwritten?
-        '@type': 'Contact', // cannot be overwritten
+        '@id': '{{ownerUri}}', // can't be overwritten
+        '@type': 'Contact', // can't be overwritten
         'vcard:fn': '{{owner}}',
-        'vcard:hasEmail': '{{orgContactUrl}}',
+        'vcard:hasEmail': '{{orgContactEmail}}',
     },
     'dct:publisher': '{{orgTitle}}',
-    'dcat:theme': 'geospatial', // TODO update this to use this vocabulary http://publications.europa.eu/resource/authority/data-theme
+    'dcat:theme': 'geospatial', // can't be overwritten. TODO: update this to use this vocabulary http://publications.europa.eu/resource/authority/data-theme
     'dct:accessRights': 'public',
-    'dct:identifier': '{{landingPage}}', // Wait, can this be overwritten too?
-    'dcat:keyword': '{{keyword}}',
+    'dct:identifier': '{{landingPage}}', // can't be overwritten
+    'dcat:keyword': '{{keyword}}', // can't be overwritten
     'dct:provenance': '{{provenance}}', // won't be available if not INSPIRE metadata
-    'dct:issued': '{{issuedDateTime}}',
-    'dct:language': null,
+    'dct:issued': '{{issuedDateTime}}', // can't be overwritten
+    'dct:language': '', // can't be overwritten, object computed at runtime 
 };

--- a/src/default-format-template.ts
+++ b/src/default-format-template.ts
@@ -1,0 +1,22 @@
+import { DatasetFormatTemplate } from "./dcat-ap/dcat-formatters";
+
+export const defaultFormatTemplate: DatasetFormatTemplate = {
+    '@type': 'dcat:Dataset', // cannot be overwritten
+    '@id': '{{landingPage}}', // cannot be overwritten (or can it?)
+    'dct:title': '{{name}}',
+    'dct:description': '{{description}}',
+    'dcat:contactPoint': {
+        '@id': '{{ownerUri}}', // should this be overwritten?
+        '@type': 'Contact', // cannot be overwritten
+        'vcard:fn': '{{owner}}',
+        'vcard:hasEmail': '{{orgContactUrl}}',
+    },
+    'dct:publisher': '{{orgTitle}}',
+    'dcat:theme': 'geospatial', // TODO update this to use this vocabulary http://publications.europa.eu/resource/authority/data-theme
+    'dct:accessRights': 'public',
+    'dct:identifier': '{{landingPage}}', // Wait, can this be overwritten too?
+    'dcat:keyword': '{{keyword}}',
+    'dct:provenance': '{{provenance}}', // won't be available if not INSPIRE metadata
+    'dct:issued': '{{issuedDateTime}}',
+    'dct:language': null,
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,9 @@ import * as request from 'supertest';
 import * as mockDomainRecord from './test-helpers/mock-domain-record.json';
 import * as mockSiteModel from './test-helpers/mock-site-model.json';
 import * as mockDataset from './test-helpers/mock-dataset.json';
-import { IHubRequestOptions } from '@esri/hub-common';
+import { IHubRequestOptions, IModel } from '@esri/hub-common';
+import { FeedFormatterStream } from './dcat-ap/feed-formatter-stream';
+import * as _ from 'lodash';
 
 describe('Output Plugin', () => {
   let mockConfigModule;
@@ -20,7 +22,11 @@ describe('Output Plugin', () => {
   const siteHostName = 'download-test-qa-pre-a-hub.hubqa.arcgis.com';
 
   function buildPluginAndApp () {
-    const Output = require('./');
+    let Output;
+    
+    jest.isolateModules(() => {
+      Output = require('./');
+    });
 
     const plugin = new Output();
     plugin.model = {
@@ -192,5 +198,55 @@ describe('Output Plugin', () => {
       .expect(res => {
         expect(res.body).toEqual({});
       });
+  });
+
+  describe('feed configurations', () => {
+    let mockGetDataStreamDcatAp201;
+
+    beforeEach(() => {
+      const { getDataStreamDcatAp201 } = require('./dcat-ap');
+      jest.mock('./dcat-ap');
+      mockGetDataStreamDcatAp201 = mocked(getDataStreamDcatAp201)
+        .mockReturnValue({
+          dcatStream: new FeedFormatterStream('{', '}', '', () => ''),
+          dependencies: []
+        });
+    });
+
+    it("Properly passes a site's custom dcat configuration to getDataStreamAp201 when present", async () => {
+      [ plugin, app ] = buildPluginAndApp();
+
+      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
+      customConfigSiteModel.data.feeds = {
+        dcatAP201: {
+          'dct:title': '{{name}}',
+          'dct:description': '{{description}}',
+          'dcat:contactPoint': {
+              'vcard:fn': '{{owner}}',
+              'vcard:hasEmail': '{{orgContactEmail}}',
+          },
+          'dct:publisher': '{{orgTitle}}',
+          'dct:accessRights': 'public',
+          'dct:provenance': '{{provenance}}',
+          'dct:newAttribute': '{{path.to.attribute}}'
+        }
+      }
+      mockGetSite.mockResolvedValue(customConfigSiteModel);
+
+      await request(app)
+        .get('/dcat')
+        .set('host', siteHostName)
+        .expect('Content-Type', /application\/json/)
+        .expect(200)
+        .expect(() => {
+          expect(mockGetDataStreamDcatAp201)
+            .toHaveBeenCalledWith({
+              domainRecord: mockDomainRecord,
+              siteItem: customConfigSiteModel.item,
+              orgBaseUrl: 'https://qa-pre-a-hub.maps.arcgis.com',
+              customFormatTemplate: customConfigSiteModel.data.feeds.dcatAP201
+            });
+        });
+    });
   });
 });

--- a/src/test-helpers/mock-dataset.json
+++ b/src/test-helpers/mock-dataset.json
@@ -1,6 +1,7 @@
 {
   "errors": [],
   "access": "public",
+  "orgContactEmail": "mailto:email@service.com",
   "additionalResources": [
     {
       "url": "https://servicesqa.arcgis.com/Xj56SBi2udA78cC9/arcgis/rest/services/Tahoe_Things/FeatureServer"

--- a/src/test-helpers/stream-utils.ts
+++ b/src/test-helpers/stream-utils.ts
@@ -13,7 +13,7 @@ export function readableFromArray (arr: Array<any>) {
   return docStream;
 }
 
-export function streamToString (stream: Readable) {
+export function streamToString (stream: Readable): Promise<string> {
   const chunks = [];
   return new Promise((resolve, reject) => {
     stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));


### PR DESCRIPTION
As part of [2393](https://devtopia.esri.com/dc/hub/issues/2393), this plugin now utilizes the custom configuration found at `site.data.feeds.dcatAP201`.

In order to accomplish this, I overhauled the plugin to:
- Follow the functional (rather than object oriented) model. This allowed for flexibility in handling different feed schemas.
- Utilize the adlib library to interpolate the dynamic feed schemas.
- Scrub protected fields from custom configurations and merge remaining customizations with the default schema.
- Test situations where custom configurations are used.

Many changes were made to bring this plugin into better alignment with the [DCAT-US 1.1 plugin](https://github.com/koopjs/koop-output-dcat-us-11), which already had this functionality.