### PR TITLE
Scrub attempts to overwrite the 'dct:publisher', 'dct:provenance' and 'dct:accessRights'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # CHANGELOG.md
 
+## Unreleased
+
+Fixed
+- Scrub configurations that attempt to overwrite the 'dct:publisher', 'dct:provenance' and 'dct:accessRights' properties [#10](https://github.com/koopjs/koop-output-dcat-ap-201/pull/10)
+
 ## 1.2.0
+
 Added
-- support to use the custom template configuration found on the site's `data.feeds.dcatAP201` property
+- support to use the custom template configuration found on the site's `data.feeds.dcatAP201` property [#9](https://github.com/koopjs/koop-output-dcat-ap-201/pull/9)
 
 ## 1.1.0
+
 Added
-- `orgContactEmail` as property of feed [#8](https://github.com/koopjs/koop-output-dcat-ap-201/pull/4)
+- `orgContactEmail` as property of feed [#8](https://github.com/koopjs/koop-output-dcat-ap-201/pull/8)
 
 ## 1.0.1
 

--- a/src/dcat-ap/dcat-formatters.ts
+++ b/src/dcat-ap/dcat-formatters.ts
@@ -259,9 +259,12 @@ export function scrubProtectedKeys(template: DatasetFormatTemplate): DatasetForm
     scrubbedTemplate['dcat:contactPoint']['@type'] = 'Contact';
   }
 
+  delete scrubbedTemplate['dct:publisher'];
   delete scrubbedTemplate['dcat:theme'];
+  delete scrubbedTemplate['dct:accessRights'];
   delete scrubbedTemplate['dct:identifier']; 
   delete scrubbedTemplate['dcat:keyword']; 
+  delete scrubbedTemplate['dct:provenance'];
   delete scrubbedTemplate['dct:issued']; 
   delete scrubbedTemplate['dct:language'];
   delete scrubbedTemplate['dcat:distribution'];

--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -253,9 +253,12 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
           "vcard:fn": "{{ owner}}", // default value
           "vcard:hasEmail": "{{ orgContactEmail }}", // default value
         },
+        'dct:publisher': '{{ Publisher Injection }}',
         'dcat:theme': '{{ Theme Injection }}',
+        'dct:accessRights': '{{ Access Rights Injection }}',
         'dct:identifier': '{{ Identifier Injection}}',
         'dcat:keyword': '{{ Keyword Injection }}',
+        'dct:provenance': '{{ Provenance Injection }}',
         'dct:issued': '{{ Issued Injection}}',
         'dct:language': '{{ Language Injection }}',
         'dcat:distribution': '{{ Distribution Injection }}',

--- a/src/default-format-template.ts
+++ b/src/default-format-template.ts
@@ -11,12 +11,12 @@ export const defaultFormatTemplate: DatasetFormatTemplate = {
         'vcard:fn': '{{owner}}',
         'vcard:hasEmail': '{{orgContactEmail}}',
     },
-    'dct:publisher': '{{orgTitle}}',
+    'dct:publisher': '{{orgTitle}}', // can't be overwritten
     'dcat:theme': 'geospatial', // can't be overwritten. TODO: update this to use this vocabulary http://publications.europa.eu/resource/authority/data-theme
-    'dct:accessRights': 'public',
+    'dct:accessRights': 'public', // can't be overwritten
     'dct:identifier': '{{landingPage}}', // can't be overwritten
     'dcat:keyword': '{{keyword}}', // can't be overwritten
-    'dct:provenance': '{{provenance}}', // won't be available if not INSPIRE metadata
+    'dct:provenance': '{{provenance}}', // can't be overwritten. won't be available if not INSPIRE metadata
     'dct:issued': '{{issuedDateTime}}', // can't be overwritten
     'dct:language': '', // can't be overwritten, object computed at runtime 
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -225,9 +225,6 @@ describe('Output Plugin', () => {
               'vcard:fn': '{{owner}}',
               'vcard:hasEmail': '{{orgContactEmail}}',
           },
-          'dct:publisher': '{{orgTitle}}',
-          'dct:accessRights': 'public',
-          'dct:provenance': '{{provenance}}',
           'dct:newAttribute': '{{path.to.attribute}}'
         }
       }


### PR DESCRIPTION
Fixes comment left on [1696](https://devtopia.esri.com/dc/hub/issues/1696#issuecomment-3175523)