### PR TITLE
F/2342 add id query param

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,6 @@ import { mocked } from 'ts-jest/utils';
 
 import { readableFromArray } from './test-helpers/stream-utils';
 import * as express from 'express';
-import { IItem } from '@esri/arcgis-rest-types';
 import * as request from 'supertest';
 
 import * as mockDomainRecord from './test-helpers/mock-domain-record.json';
@@ -183,12 +182,9 @@ describe('Output Plugin', () => {
   it('returns empty response if no site catalog', async () => {
     [ plugin, app ] = buildPluginAndApp();
 
-    mockGetSite.mockResolvedValue({
-      item: {} as IItem,
-      data: {
-        // no site catalog
-      }
-    });
+    const siteWithoutCatalogOrFeed: IModel = _.cloneDeep(mockSiteModel);
+    siteWithoutCatalogOrFeed.data = {}
+    mockGetSite.mockResolvedValue(siteWithoutCatalogOrFeed);
 
     await request(app)
       .get('/dcat')

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,17 +55,20 @@ export = class OutputDcatAp201 {
         env === 'prod' ? '' : env
       }.arcgis.com`;
 
+      const id = String(req.query.id || '');
+
       const dcatStream = getDataStreamDcatAp201({
         domainRecord,
         siteItem: siteModel.item,
         orgBaseUrl,
       });
 
-      req.res.locals.searchRequest = this.getSearchRequest(
-        siteCatalog,
+      req.res.locals.searchRequest = this.getSearchRequest({
+        catalog: siteCatalog,
+        id,
         portalUrl,
-        requiredFields
-      );
+        fields: requiredFields
+      });
 
       const datasetStream = await this.model.pullStream(req);
 
@@ -101,19 +104,23 @@ export = class OutputDcatAp201 {
     };
   }
 
-  private getSearchRequest(
+  private getSearchRequest(opts: {
     catalog: any,
+    id: string,
     portalUrl: string,
     fields: string[]
-  ): IContentSearchRequest {
+  }): IContentSearchRequest {
+    const filter = opts.id
+      ? { id: opts.id }
+      : { group: opts.catalog?.groups, orgid: opts.catalog?.orgId };
+
+    const fields = opts.fields ? opts.fields.join(',') : undefined;
+
     const searchRequest: IContentSearchRequest = {
-      filter: {
-        group: catalog.groups,
-        orgid: catalog.orgId,
-      },
+      filter,
       options: {
         portal: portalUrl,
-        fields: fields.join(',')
+        fields
       },
     };
     return searchRequest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export = class OutputDcatAp201 {
       const orgBaseUrl = `https://${domainRecord.orgKey}.maps${
         env === 'prod' ? '' : env
       }.arcgis.com`;
-      
+
       const { dcatStream, dependencies } = getDataStreamDcatAp201({
         domainRecord,
         siteItem: siteModel.item,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,34 +50,40 @@ export = class OutputDcatAp201 {
     try {
       const { domainRecord, siteModel } = await this.fetchDomainAndSite(req.hostname);
 
-      const siteCatalog = _.get(siteModel, 'data.catalog');
-      if (!siteCatalog) {
-        res.status(200).send({});
-        return;
+      // Use dcatConfig query param if provided, else default to site's config
+      let dcatConfig = typeof req.query.dcatConfig === 'string'
+        ? this.parseProvidedDcatConfig(req.query.dcatConfig as string)
+        : req.query.dcatConfig;
+    
+      if (!dcatConfig) {
+        dcatConfig = _.get(siteModel, 'data.feeds.dcatAP201');
       }
+
       const orgBaseUrl = `https://${domainRecord.orgKey}.maps${
         env === 'prod' ? '' : env
       }.arcgis.com`;
-
-      const customFormatTemplate = _.get(siteModel, 'data.feeds.dcatAP201');
       
       const { dcatStream, dependencies } = getDataStreamDcatAp201({
         domainRecord,
         siteItem: siteModel.item,
         orgBaseUrl,
-        customFormatTemplate
+        customFormatTemplate: dcatConfig
       });
       
       const apiTerms = getApiTermsFromDependencies(dependencies);
       
+      // Construct request to send, send empty if no id or catalog
       const id = String(req.query.id || '');
+      const siteCatalog = _.get(siteModel, 'data.catalog');
 
-      req.res.locals.searchRequest = this.getSearchRequest({
-        id,
-        catalog: siteCatalog,
-        portalUrl,
-        fields: apiTerms
-      });
+      if (!id && !siteCatalog) {
+        res.status(200).send({});
+        return;
+      }
+  
+      req.res.locals.searchRequest = id 
+        ? this.getDatasetSearchRequest({ id, portalUrl, fields: apiTerms })
+        : this.getCatalogSearchRequest({ catalog: siteCatalog, portalUrl, fields: apiTerms });
 
       const datasetStream = await this.model.pullStream(req);
 
@@ -104,6 +110,14 @@ export = class OutputDcatAp201 {
     return { domainRecord, siteModel };
   }
 
+  private parseProvidedDcatConfig(dcatConfig: string) {
+    try {
+      return JSON.parse(dcatConfig);
+    } catch (err) {
+      return undefined;
+    }
+  }
+
   private getRequestOptions(portalUrl: string): IHubRequestOptions {
     return {
       isPortal: false,
@@ -113,23 +127,34 @@ export = class OutputDcatAp201 {
     };
   }
 
-  private getSearchRequest(opts: {
-    catalog: any,
+  private getDatasetSearchRequest(opts: {
     id: string,
     portalUrl: string,
     fields: string[]
   }): IContentSearchRequest {
-    const filter = opts.id
-      ? { id: opts.id }
-      : { group: opts.catalog?.groups, orgid: opts.catalog?.orgId };
-
-    const fields = opts.fields ? opts.fields.join(',') : undefined;
-
     const searchRequest: IContentSearchRequest = {
-      filter,
+      filter: { id: opts.id },
       options: {
         portal: portalUrl,
-        fields
+        fields: opts.fields ? opts.fields.join(',') : undefined
+      },
+    };
+    return searchRequest;
+  }
+
+  private getCatalogSearchRequest(opts: {
+    catalog: any,
+    portalUrl: string,
+    fields: string[]
+  }): IContentSearchRequest {
+    const searchRequest: IContentSearchRequest = {
+      filter: {
+        group: opts.catalog.groups,
+        orgid: opts.catalog.orgId,
+      },
+      options: {
+        portal: portalUrl,
+        fields: opts.fields ? opts.fields.join(',') : undefined
       },
     };
     return searchRequest;


### PR DESCRIPTION
[2342](https://devtopia.esri.com/dc/hub/issues/2342) as a prerequisite for previewing the dcat-ap feed, the id and dcat query params should be able to be parsed.