### PR TITLE
allow customers to append custom distributions to the `dcat:distribution` array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG.md
+## Unreleased
+Added
+- If the `dcat:distribution` property of a site's dcat config is an array, those custom distributions will now be prepended to the distributions list [#18](https://github.com/koopjs/koop-output-dcat-ap-201/pull/18)
 
 ## 1.6.2
 Fixed

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -244,11 +244,11 @@
         "@esri/arcgis-rest-auth": "^3.2.1",
         "@esri/arcgis-rest-portal": "^3.2.1",
         "@esri/arcgis-rest-request": "^3.2.1",
-        "@esri/hub-common": "^9.17.1",
-        "@esri/hub-initiatives": "^9.17.1",
-        "@esri/hub-search": "^9.17.1",
-        "@esri/hub-sites": "^9.17.1",
-        "@esri/hub-teams": "^9.17.1",
+        "@esri/hub-common": "^9.27.0",
+        "@esri/hub-initiatives": "^9.27.0",
+        "@esri/hub-search": "^9.27.0",
+        "@esri/hub-sites": "^9.27.0",
+        "@esri/hub-teams": "^9.27.0",
         "config": "^3.3.6",
         "lodash": "^4.17.21",
         "tslib": "~2.3.0"
@@ -323,12 +323,13 @@
           "integrity": "sha512-lVOAhu0qvhQEm5BFSOp8VxqxkAd5dBa7ZNXhtuDNNyELy38R0C/0zt3ri4eQLpMIZG4oip/djinOLgzAdQZzBw=="
         },
         "@esri/hub-common": {
-          "version": "9.16.0",
-          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.16.0.tgz",
-          "integrity": "sha512-wLBKkoWwKyj3N5swGJ91R0YlF/Vb9qrLBeNS1qPV5AbaWAk5M3su4wkShN1wOL4T+6FluYccOeUrzBZ60tu1YA==",
+          "version": "9.28.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.28.0.tgz",
+          "integrity": "sha512-TUzcpmcwjPRZR0nl62s93nzvB2n1EkuAvG7RZt1+XcifFF+VC8x2PYHiqdR9h+IoL+OkZmyNFltk/FHG8Uqfhw==",
           "requires": {
             "abab": "^2.0.5",
             "adlib": "^3.0.7",
+            "fast-xml-parser": "~3.2.4",
             "jsonapi-typescript": "^0.1.3",
             "tslib": "^1.13.0"
           },
@@ -341,9 +342,9 @@
           }
         },
         "@esri/hub-initiatives": {
-          "version": "9.16.0",
-          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.16.0.tgz",
-          "integrity": "sha512-gHl3iRDHaHyeLjHiC1NhbrBgSYOBVSbJAgkRhFYQrILlyA7lQxN9G8fD52ioc14x++yTgpCB117sqUHAW4WftQ==",
+          "version": "9.28.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.28.0.tgz",
+          "integrity": "sha512-Nyp9TSMwmajduu1m+eZ+96Iv+ZrMPxKT95A5YFjlPaEDPaGrT0IuqPkOM48w9IBxn4Nn915Z0bwTzA7wg3XSVg==",
           "requires": {
             "tslib": "^1.13.0"
           },
@@ -356,9 +357,9 @@
           }
         },
         "@esri/hub-search": {
-          "version": "9.16.0",
-          "resolved": "https://registry.npmjs.org/@esri/hub-search/-/hub-search-9.16.0.tgz",
-          "integrity": "sha512-K8pOaxe1nEUWJOEj0nDnz24SzIE4aORrbCo6dEg804Q/J4ub9dJeCwMqj5BIV30chga+fz6KM7NLC7HdAoaZ/Q==",
+          "version": "9.28.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-search/-/hub-search-9.28.0.tgz",
+          "integrity": "sha512-1h57oDlNUsk/V840gMy0omKITDc2KbYcWpEGKBYLbtjFK2BUvkYGyxy8WpoL/1hki5vyJZbk9BvwusfVpQNRMA==",
           "requires": {
             "tslib": "^1.13.0"
           },
@@ -371,9 +372,9 @@
           }
         },
         "@esri/hub-sites": {
-          "version": "9.16.0",
-          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.16.0.tgz",
-          "integrity": "sha512-cwh1wc5MKzD26VzQmDJ0tIEnKmWd1sC9R6v3R1bWK6UKLlYPkhYbgMZ58tyesZzzcoshbSe5ftOs34IFoxzzBA==",
+          "version": "9.28.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.28.0.tgz",
+          "integrity": "sha512-GuUth+DSj6mI9r1i+wBtpLGRPFVowwYWJaElDwF8O0AVV08KwEGM0YOFyHhvt8DY8JzBSuykMNeWlAec90O+XQ==",
           "requires": {
             "tslib": "^1.13.0"
           },
@@ -386,9 +387,9 @@
           }
         },
         "@esri/hub-teams": {
-          "version": "9.16.0",
-          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.16.0.tgz",
-          "integrity": "sha512-0uvrTJaOmobdbWHSGWmdcfqTfqJDHE10R+N3TTPNgiqLvlmJprApq2yO2wuudh8Ol6GIAjUD9SPINd35b5LSSQ==",
+          "version": "9.28.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.28.0.tgz",
+          "integrity": "sha512-iWzkl6+OUETLfaJL7cjcIXX8vdy3YTdhRxYskMqTpX5UuLH7hRNYRYgLylOj5LShqVi+cQWCPtUFVGDPod7RAA==",
           "requires": {
             "tslib": "^1.13.0"
           },
@@ -420,9 +421,9 @@
           }
         },
         "abab": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-          "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+          "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
         },
         "adlib": {
           "version": "3.0.7",
@@ -432,10 +433,81 @@
             "esm": "^3.2.25"
           }
         },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
         "asynckit": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "babel-polyfill": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+          "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
         },
         "combined-stream": {
           "version": "1.0.8",
@@ -453,15 +525,71 @@
             "json5": "^2.1.1"
           }
         },
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "encoding": {
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+          "requires": {
+            "iconv-lite": "^0.6.2"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+              "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+              }
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
         "esm": {
           "version": "3.2.25",
           "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
           "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
+          "integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
+          "requires": {
+            "he": "~1.1.1",
+            "nimnjs": "^1.1.0",
+            "opencollective": "^1.0.3"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
         },
         "form-data": {
           "version": "3.0.1",
@@ -472,6 +600,57 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.1",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "isomorphic-fetch": {
           "version": "3.0.0",
@@ -541,15 +720,197 @@
             "mime-db": "1.48.0"
           }
         },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "nimn-date-parser": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
+          "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
+        },
+        "nimn_schema_builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
+          "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
+        },
+        "nimnjs": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
+          "integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
+          "requires": {
+            "nimn-date-parser": "^1.0.0",
+            "nimn_schema_builder": "^1.0.0"
+          }
+        },
         "node-fetch": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
           "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "opencollective": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+          "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+          "requires": {
+            "babel-polyfill": "6.23.0",
+            "chalk": "1.1.3",
+            "inquirer": "3.0.6",
+            "minimist": "1.2.0",
+            "node-fetch": "1.6.3",
+            "opn": "4.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "node-fetch": {
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+              "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+              "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+              }
+            }
+          }
+        },
+        "opn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+          "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+        },
+        "rx": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+          "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+              "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
         },
         "tslib": {
           "version": "2.3.0",

--- a/src/dcat-ap/dcat-formatters.test.ts
+++ b/src/dcat-ap/dcat-formatters.test.ts
@@ -118,16 +118,8 @@ describe('formatDcatDataset', () => {
     expect(result['dct:language']).toBe('');
   });
 
-  it('DCAT distributions have correct format', function () {
-    const distDataset = {
-      ...dataset,
-      landingPage: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/maps/0_0',
-      downloadLink: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0',
-      id: '0_0',
-      geometryType: 'point',
-      supportedExtensions: ['WFSServer', 'WMSServer']
-    };
-    const expectedResult = {
+  describe('distributions', () => {
+    const distributions = {
       html: {
         '@type': 'dcat:Distribution',
         'dcat:accessUrl':
@@ -203,91 +195,154 @@ describe('formatDcatDataset', () => {
         'dct:title': 'OGC WMS',
       },
     };
-    const result = JSON.parse(formatDcatDataset(distDataset, defaultFormatTemplate));
-    expect(result['dcat:distribution'][0]).toEqual(expectedResult.html);
-    expect(result['dcat:distribution'][1]).toEqual(expectedResult.restAPI);
-    expect(result['dcat:distribution'][2]).toEqual(expectedResult.geoJSON);
-    expect(result['dcat:distribution'][3]).toEqual(expectedResult.csv);
-    expect(result['dcat:distribution'][4]).toEqual(expectedResult.wfs);
-    expect(result['dcat:distribution'][5]).toEqual(expectedResult.kml);
-    expect(result['dcat:distribution'][6]).toEqual(expectedResult.zip);
-    expect(result['dcat:distribution'][7]).toEqual(expectedResult.wms);
-  });
 
-  it('basic DCAT distributions are generated', function () {
-    const result = JSON.parse(formatDcatDataset(dataset, defaultFormatTemplate));
-    const dist1 = result['dcat:distribution'][0]['dct:title'];
-    const dist2 = result['dcat:distribution'][1]['dct:title'];
+    const getDistributions = (dataset: any, template: any) => {
+      const formattedDataset = JSON.parse(
+        formatDcatDataset(dataset, template)
+      );
+      return formattedDataset['dcat:distribution'];
+    }
 
-    expect(dist2).toBeTruthy();
-    expect(dist1).toBe('ArcGIS Hub Dataset');
-    expect(dist2).toBe('ArcGIS GeoService');
-  });
-
-  it('FeatureLayer DCAT distributions are generated', function () {
-    const featureLayerDataset = {
-      ...dataset,
-      id: '0_0',
-    };
-    const result = JSON.parse(formatDcatDataset(featureLayerDataset, defaultFormatTemplate));
-    const dist1 = result['dcat:distribution'][2]['dct:title'];
-    const dist2 = result['dcat:distribution'][3]['dct:title'];
-
-    expect(dist2).toBeTruthy();
-    expect(dist1).toBe('GeoJSON');
-    expect(dist2).toBe('CSV');
-  });
-
-  it('FeatureLayer DCAT distributions with available geometryType are generated', function () {
-    const featureLayerDataset = {
-      ...dataset,
-      isFeatureLayer: true,
-      hasGeometryType: true,
-      id: '0_0',
-      geometryType: 'point',
-    };
-    const result = JSON.parse(formatDcatDataset(featureLayerDataset, defaultFormatTemplate));
-    const dist1 = result['dcat:distribution'][4]['dct:title'];
-    const dist2 = result['dcat:distribution'][5]['dct:title'];
-
-    expect(dist2).toBeTruthy();
-    expect(dist1).toBe('KML');
-    expect(dist2).toBe('ZIP');
-  });
-
-  it('DCAT distributions include WFS when supported', function () {
-    const WFSDataset = { 
-      ...dataset,
-      supportedExtensions: ['WFSServer']
-    };
-    const result = JSON.parse(formatDcatDataset(WFSDataset, defaultFormatTemplate));
-    const dist = result['dcat:distribution'][2]['dct:title'];
-
-    expect(dist).toBeTruthy();
-    expect(dist).toBe('OGC WFS');
-  });
-
-  it('DCAT distributions include WMS when supported', function () {
-    const WMSDataset = { 
-      ...dataset,
-      supportedExtensions: ['WMSServer']
-    };
-    const result = JSON.parse(formatDcatDataset(WMSDataset, defaultFormatTemplate));
-    const dist = result['dcat:distribution'][2]['dct:title'];
-
-    expect(dist).toBeTruthy();
-    expect(dist).toBe('OGC WMS');
-  });
-
-  it('Proxied CSV DCAT distributions are generated', function () {
-    const proxiedCSVDataset = {
-      ...dataset,
-      type: 'CSV',
-      size: 1,
-      url: null,
-    };
-    const result = JSON.parse(formatDcatDataset(proxiedCSVDataset, defaultFormatTemplate));
-    expect(result['dcat:distribution']).toHaveLength(3);
-    expect(result['dcat:distribution'][2]['dct:title']).toBe('CSV');
+    it('All DCAT distributions have correct format', function () {
+      const distDataset = {
+        ...dataset,
+        landingPage: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/maps/0_0',
+        downloadLink: 'https://jules-goes-the-distance-qa-pre-a-hub.hubqa.arcgis.com/datasets/0_0',
+        id: '0_0',
+        geometryType: 'point',
+        supportedExtensions: ['WFSServer', 'WMSServer']
+      };
+      
+      const result = JSON.parse(formatDcatDataset(distDataset, defaultFormatTemplate));
+      expect(result['dcat:distribution'][0]).toEqual(distributions.html);
+      expect(result['dcat:distribution'][1]).toEqual(distributions.restAPI);
+      expect(result['dcat:distribution'][2]).toEqual(distributions.geoJSON);
+      expect(result['dcat:distribution'][3]).toEqual(distributions.csv);
+      expect(result['dcat:distribution'][4]).toEqual(distributions.wfs);
+      expect(result['dcat:distribution'][5]).toEqual(distributions.kml);
+      expect(result['dcat:distribution'][6]).toEqual(distributions.zip);
+      expect(result['dcat:distribution'][7]).toEqual(distributions.wms);
+    });
+  
+    it('basic DCAT distributions are generated', function () {
+      const result = getDistributions(dataset, defaultFormatTemplate);
+      expect(result).toHaveLength(2);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+    });
+  
+    it('FeatureLayer DCAT distributions are generated', function () {
+      const featureLayerDataset = {
+        ...dataset,
+        id: '0_0',
+      };
+      const result = getDistributions(featureLayerDataset, defaultFormatTemplate);
+      expect(result).toHaveLength(4);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.geoJSON['dct:title']);
+      expect(result[3]['dct:title']).toEqual(distributions.csv['dct:title']);
+    });
+  
+    it('FeatureLayer DCAT distributions with available geometryType are generated', function () {
+      const featureLayerDataset = {
+        ...dataset,
+        isFeatureLayer: true,
+        hasGeometryType: true,
+        id: '0_0',
+        geometryType: 'point',
+      };
+      const result = getDistributions(featureLayerDataset, defaultFormatTemplate);
+      expect(result).toHaveLength(6);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.geoJSON['dct:title']);
+      expect(result[3]['dct:title']).toEqual(distributions.csv['dct:title']);
+      expect(result[4]['dct:title']).toEqual(distributions.kml['dct:title']);
+      expect(result[5]['dct:title']).toEqual(distributions.zip['dct:title']);
+    });
+  
+    it('DCAT distributions include WFS when supported', function () {
+      const WFSDataset = { 
+        ...dataset,
+        supportedExtensions: ['WFSServer']
+      };
+      const result = getDistributions(WFSDataset, defaultFormatTemplate);
+      expect(result).toHaveLength(3);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.wfs['dct:title']);
+    });
+  
+    it('DCAT distributions include WMS when supported', function () {
+      const WMSDataset = { 
+        ...dataset,
+        supportedExtensions: ['WMSServer']
+      };
+      const result = getDistributions(WMSDataset, defaultFormatTemplate);
+      expect(result).toHaveLength(3);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.wms['dct:title']);
+    });
+  
+    it('Proxied CSV DCAT distributions are generated', function () {
+      const proxiedCSVDataset = {
+        ...dataset,
+        type: 'CSV',
+        size: 1,
+        url: null,
+      };
+      const result = getDistributions(proxiedCSVDataset, defaultFormatTemplate);
+      expect(result).toHaveLength(3);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.csv['dct:title']);
+    });
+  
+    it('Custom distributions are generated when template contains non-empty array', function () {
+      const customDistributionsTemplates = {
+        ...defaultFormatTemplate,
+        'dcat:distribution': [
+          {
+            myKey: '{{name}}',
+            myConstant: 'constant'
+          }
+        ]
+      };
+      const result = getDistributions(dataset, customDistributionsTemplates);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        myKey: 'Jules Goes The Distance',
+        myConstant: 'constant'
+      });
+      expect(result[1]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[2]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+    });
+  
+    it('Custom distributions are not generated when template contains empty array', function () {
+      const customDistributionsTemplates = {
+        ...defaultFormatTemplate,
+        'dcat:distribution': [],
+      }
+      const result = getDistributions(dataset, customDistributionsTemplates);
+      expect(result).toHaveLength(2);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+    });
+  
+    it('Custom distributions are not generated when template contains an object', function () {
+      const customDistributionsTemplates = {
+        ...defaultFormatTemplate,
+        'dcat:distribution': {
+          myKey: '{{name}}',
+          myConstant: 'constant'
+        },
+      }
+      const result = getDistributions(dataset, customDistributionsTemplates);
+      expect(result).toHaveLength(2);
+      expect(result[0]['dct:title']).toEqual(distributions.html['dct:title']);
+      expect(result[1]['dct:title']).toEqual(distributions.restAPI['dct:title']);
+    });
   });
 });

--- a/src/dcat-ap/dcat-formatters.test.ts
+++ b/src/dcat-ap/dcat-formatters.test.ts
@@ -213,15 +213,15 @@ describe('formatDcatDataset', () => {
         supportedExtensions: ['WFSServer', 'WMSServer']
       };
       
-      const result = JSON.parse(formatDcatDataset(distDataset, defaultFormatTemplate));
-      expect(result['dcat:distribution'][0]).toEqual(distributions.html);
-      expect(result['dcat:distribution'][1]).toEqual(distributions.restAPI);
-      expect(result['dcat:distribution'][2]).toEqual(distributions.geoJSON);
-      expect(result['dcat:distribution'][3]).toEqual(distributions.csv);
-      expect(result['dcat:distribution'][4]).toEqual(distributions.wfs);
-      expect(result['dcat:distribution'][5]).toEqual(distributions.kml);
-      expect(result['dcat:distribution'][6]).toEqual(distributions.zip);
-      expect(result['dcat:distribution'][7]).toEqual(distributions.wms);
+      const result = getDistributions(distDataset, defaultFormatTemplate);
+      expect(result[0]).toEqual(distributions.html);
+      expect(result[1]).toEqual(distributions.restAPI);
+      expect(result[2]).toEqual(distributions.geoJSON);
+      expect(result[3]).toEqual(distributions.csv);
+      expect(result[4]).toEqual(distributions.wfs);
+      expect(result[5]).toEqual(distributions.kml);
+      expect(result[6]).toEqual(distributions.zip);
+      expect(result[7]).toEqual(distributions.wms);
     });
   
     it('basic DCAT distributions are generated', function () {

--- a/src/dcat-ap/noneditable-fields.ts
+++ b/src/dcat-ap/noneditable-fields.ts
@@ -12,5 +12,4 @@ export const nonEditableFieldPaths = [
   'dct:language',
   'dcat:contactPoint[@id]',
   'dcat:contactPoint[@type]',
-  'dcat:distribution'
 ];


### PR DESCRIPTION
Part of https://devtopia.esri.com/dc/hub/issues/1188.
To allow customers to add custom distributions to their feed via their dcat config, I made a few changes:
- Remove `dcat:distribution` from the list of non-editable fields
- Run customizations of `dcat:distribution` through adlib
- Prepend the result from adlib onto the final `dcat:distribution` array IFF the adlib result is an array

We are not adding any validation as part of this PR. If the dcat config's `dcat:distribution` is an array, we just throw it in there.