### PR TITLE
B/6296 fix dcat ap validator

### DIFF
--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -20,7 +20,8 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
       foaf: 'http://xmlns.com/foaf/0.1/',
       vcard: 'http://www.w3.org/2006/vcard/ns#',
       ftype: 'http://publications.europa.eu/resource/authority/file-type/',
-      lang: 'http://publications.europa.eu/resource/authority/language/'
+      lang: 'http://publications.europa.eu/resource/authority/language/',
+      skos: "http://www.w3.org/2004/02/skos/core#"
     });
     expect(feed['dcat:dataset']).toBeInstanceOf(Array);
     expect(feed['dcat:dataset'].length).toBe(1);

--- a/src/dcat-ap/index.ts
+++ b/src/dcat-ap/index.ts
@@ -10,6 +10,7 @@ const DEFAULT_CATALOG_HEADER = {
     vcard: 'http://www.w3.org/2006/vcard/ns#',
     ftype: 'http://publications.europa.eu/resource/authority/file-type/',
     lang: 'http://publications.europa.eu/resource/authority/language/',
+    skos: "http://www.w3.org/2004/02/skos/core#"
   }
 };
 const FOOTER = '\n\t]\n}';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -107,7 +107,8 @@ describe('Output Plugin', () => {
           foaf: 'http://xmlns.com/foaf/0.1/',
           vcard: 'http://www.w3.org/2006/vcard/ns#',
           ftype: 'http://publications.europa.eu/resource/authority/file-type/',
-          lang: 'http://publications.europa.eu/resource/authority/language/'
+          lang: 'http://publications.europa.eu/resource/authority/language/',
+          skos: "http://www.w3.org/2004/02/skos/core#"
         });
         expect(dcatStream['dcat:dataset']).toBeInstanceOf(Array);
         expect(dcatStream['dcat:dataset'].length).toBe(1);


### PR DESCRIPTION
Adds `skos` context to define `dcat:theme`.

Related: https://devtopia.esri.com/dc/hub/issues/6296