### PR TITLE
add access and date context

### DIFF
--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -21,7 +21,9 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
       vcard: 'http://www.w3.org/2006/vcard/ns#',
       ftype: 'http://publications.europa.eu/resource/authority/file-type/',
       lang: 'http://publications.europa.eu/resource/authority/language/',
-      skos: "http://www.w3.org/2004/02/skos/core#"
+      skos: "http://www.w3.org/2004/02/skos/core#",
+      access: "http://publications.europa.eu/resource/authority/access-right/",
+      xsd: "http://www.w3.org/2001/XMLSchema#"
     });
     expect(feed['dcat:dataset']).toBeInstanceOf(Array);
     expect(feed['dcat:dataset'].length).toBe(1);

--- a/src/dcat-ap/index.ts
+++ b/src/dcat-ap/index.ts
@@ -10,7 +10,9 @@ const DEFAULT_CATALOG_HEADER = {
     vcard: 'http://www.w3.org/2006/vcard/ns#',
     ftype: 'http://publications.europa.eu/resource/authority/file-type/',
     lang: 'http://publications.europa.eu/resource/authority/language/',
-    skos: "http://www.w3.org/2004/02/skos/core#"
+    skos: "http://www.w3.org/2004/02/skos/core#",
+    access: "http://publications.europa.eu/resource/authority/access-right/",
+    xsd: "http://www.w3.org/2001/XMLSchema#"
   }
 };
 const FOOTER = '\n\t]\n}';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -108,7 +108,9 @@ describe('Output Plugin', () => {
           vcard: 'http://www.w3.org/2006/vcard/ns#',
           ftype: 'http://publications.europa.eu/resource/authority/file-type/',
           lang: 'http://publications.europa.eu/resource/authority/language/',
-          skos: "http://www.w3.org/2004/02/skos/core#"
+          skos: "http://www.w3.org/2004/02/skos/core#",
+          access: "http://publications.europa.eu/resource/authority/access-right/",
+          xsd: "http://www.w3.org/2001/XMLSchema#"
         });
         expect(dcatStream['dcat:dataset']).toBeInstanceOf(Array);
         expect(dcatStream['dcat:dataset'].length).toBe(1);


### PR DESCRIPTION
[6620](https://devtopia.esri.com/dc/hub/issues/6620): Add date(xsd) and access context for DCAT AP 2.1.1 upgrade.