### PR TITLE
Revert "add access and date context"

### DIFF
--- a/src/dcat-ap/index.test.ts
+++ b/src/dcat-ap/index.test.ts
@@ -21,9 +21,7 @@ describe('generating DCAT-AP 2.0.1 feed', () => {
       vcard: 'http://www.w3.org/2006/vcard/ns#',
       ftype: 'http://publications.europa.eu/resource/authority/file-type/',
       lang: 'http://publications.europa.eu/resource/authority/language/',
-      skos: "http://www.w3.org/2004/02/skos/core#",
-      access: "http://publications.europa.eu/resource/authority/access-right/",
-      xsd: "http://www.w3.org/2001/XMLSchema#"
+      skos: "http://www.w3.org/2004/02/skos/core#"
     });
     expect(feed['dcat:dataset']).toBeInstanceOf(Array);
     expect(feed['dcat:dataset'].length).toBe(1);

--- a/src/dcat-ap/index.ts
+++ b/src/dcat-ap/index.ts
@@ -10,9 +10,7 @@ const DEFAULT_CATALOG_HEADER = {
     vcard: 'http://www.w3.org/2006/vcard/ns#',
     ftype: 'http://publications.europa.eu/resource/authority/file-type/',
     lang: 'http://publications.europa.eu/resource/authority/language/',
-    skos: "http://www.w3.org/2004/02/skos/core#",
-    access: "http://publications.europa.eu/resource/authority/access-right/",
-    xsd: "http://www.w3.org/2001/XMLSchema#"
+    skos: "http://www.w3.org/2004/02/skos/core#"
   }
 };
 const FOOTER = '\n\t]\n}';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -108,9 +108,7 @@ describe('Output Plugin', () => {
           vcard: 'http://www.w3.org/2006/vcard/ns#',
           ftype: 'http://publications.europa.eu/resource/authority/file-type/',
           lang: 'http://publications.europa.eu/resource/authority/language/',
-          skos: "http://www.w3.org/2004/02/skos/core#",
-          access: "http://publications.europa.eu/resource/authority/access-right/",
-          xsd: "http://www.w3.org/2001/XMLSchema#"
+          skos: "http://www.w3.org/2004/02/skos/core#"
         });
         expect(dcatStream['dcat:dataset']).toBeInstanceOf(Array);
         expect(dcatStream['dcat:dataset'].length).toBe(1);


### PR DESCRIPTION
Reverts koopjs/koop-output-dcat-ap-201#41 to include DCAT AP 2.1.1 changes in major release 3.0.0 instead of 2.1.0 per  suggestion [here](https://devtopia.esri.com/dc/hub-feeds-api/pull/154/files#r1036239).