### PR TITLE
handle stream error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,12 @@ export = class OutputDcatAp201 {
       const { dcatStream } = getDataStreamDcatAp201(feedTemplate, feedTemplateTransformsDcatAp);
 
       const datasetStream = await this.getDatasetStream(req);
-
-      datasetStream
-        .pipe(dcatStream)
-        .pipe(res);
+      
+      datasetStream.on('error', (err) => {
+        if (req.next) {
+          req.next(err);
+        }
+      }).pipe(dcatStream).pipe(res);
 
     } catch (err) {
       res.status(err.statusCode).send(this.getErrorResponse(err));


### PR DESCRIPTION
This PR passes downstream error from koop providers to koop server instance which would handle the error.

https://devtopia.esri.com/dc/hub/issues/10625