### PR TITLE
add dct context

### DIFF
--- a/src/dcat-ap/constants/headers.ts
+++ b/src/dcat-ap/constants/headers.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CATALOG_HEADER_3X = {
     '@protected': true,
     adms: 'http://www.w3.org/ns/adms#',
     cnt: 'http://www.w3.org/2011/content#',
+    dct: 'http://purl.org/dc/terms/',
     dash: 'http://datashapes.org/dash#',
     dcat: 'http://www.w3.org/ns/dcat#',
     dcatap: 'http://data.europa.eu/r5r/',


### PR DESCRIPTION
Add `dct` context for dcat ap 3 header required for validation.

https://devtopia.esri.com/dc/hub/issues/13727